### PR TITLE
updated docker file to single line run command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu 
-RUN apt update 
-RUN apt install -y wget
-RUN wget https://fastdl.mongodb.org/tools/mongosync/mongosync-ubuntu2004-x86_64-1.0.0.tgz
-RUN tar -zxvf mongosync-*.tgz
-RUN cp mongosync-ubuntu2004-x86_64-1.0.0/bin/mongosync /usr/local/bin/
+RUN apt update  \
+     apt install -y wget \
+     wget https://fastdl.mongodb.org/tools/mongosync/mongosync-ubuntu2004-x86_64-1.0.0.tgz \
+     tar -zxvf mongosync-*.tgz \
+     cp mongosync-ubuntu2004-x86_64-1.0.0/bin/mongosync /usr/local/bin/ 
 EXPOSE 27182
 
 COPY ./start_mongosync.sh /


### PR DESCRIPTION
I would use single-line instruction. It's considered to be a best practice for docker. So that you minimize number of layers(RUN is one of instructions that create layers). As of multiple instructions for collecting dependencies, sometimes it's useful during development, if you're frequently changing list of packages(or their versions). But for production image, i would avoid that.